### PR TITLE
Bug(857275) : We need to correct the automation failure preview sample in the documentation - Development

### DIFF
--- a/ej2-javascript/code-snippet/rich-text-editor/format-lists-cs1/index.js
+++ b/ej2-javascript/code-snippet/rich-text-editor/format-lists-cs1/index.js
@@ -1,4 +1,4 @@
-let defaultRTE: RichTextEditor = new RichTextEditor({
+var defaultRTE = new ej.richtexteditor.RichTextEditor({
     toolbarSettings: {
         items: ['NumberFormatList', 'BulletFormatList']},
 });


### PR DESCRIPTION
### Bug description
We need to correct the automation failure preview sample in the documentation.
### Root Cause / Analysis
I have checked the sample regarding the reported problem and found some unwanted code had been implemented and improperly implemented.
### Reason for not identifying earlier
This particular use case has not been tested previously.
### Is Breaking issue.?
No
### Is reported by customer in incident/forum.?
No
### Solution Description
I have corrected the preview sample in the Kanban and Rich Text Editor component documentation.
### Areas affected and ensured
Yes
### E2E report details against this fix
No
### Did you included unit test cases.?
No
### Is there any API name changes.?
No
 
/label ~bug
/assign @ScrumMaster
/cc @ProductOwner