### PR TITLE
872396: Need to prevent the EnterAction when the mention popup is not in the open state in the mention integration sample on all platforms. - Hotfix

### DIFF
--- a/ej2-javascript/code-snippet/rich-text-editor/mention-integration-cs1/index.js
+++ b/ej2-javascript/code-snippet/rich-text-editor/mention-integration-cs1/index.js
@@ -19,10 +19,11 @@ window.emailData = [
   { Name: "William", Status: "away", EmployeeImage: "https://ej2.syncfusion.com/demos/src/rich-text-editor/images/8.png", EmailId: "william@gmail.com" }
 ];
 
+var emailObj;
 var defaultRTE = new ej.richtexteditor.RichTextEditor({
    placeholder: 'Type @ and tag the name',
    actionBegin: function (args) {
-       if (args.requestType === 'EnterAction') {
+       if (args.requestType === 'EnterAction' && emailObj.element.classList.contains('e-popup-open')) {
            args.cancel = true;
        }
    }
@@ -30,7 +31,7 @@ var defaultRTE = new ej.richtexteditor.RichTextEditor({
 defaultRTE.appendTo('#mention_integration');
 
 // Initialize Mention control.
-var emailObj = new ej.dropdowns.Mention({
+   emailObj = new ej.dropdowns.Mention({
    dataSource: emailData,
    fields: { text: 'Name' },
    suggestionCount: 8,

--- a/ej2-javascript/code-snippet/rich-text-editor/mention-integration-cs1/index.ts
+++ b/ej2-javascript/code-snippet/rich-text-editor/mention-integration-cs1/index.ts
@@ -22,10 +22,11 @@ let emailData: { [key: string]: Object }[] = [
         { Name: "William", Status: "away", EmployeeImage: "https://ej2.syncfusion.com/demos/src/rich-text-editor/images/8.png", EmailId: "william@gmail.com" }
     ];
 
+    let emailObj: Mention;
     let defaultRTE: RichTextEditor = new RichTextEditor({
         placeholder: 'Type @ and tag the name',
         actionBegin: (args) => {
-            if (args.requestType === 'EnterAction') {
+            if (args.requestType === 'EnterAction' && emailObj.element.classList.contains('e-popup-open')) {
                 args.cancel = true;
             }
         }
@@ -33,7 +34,7 @@ let emailData: { [key: string]: Object }[] = [
     defaultRTE.appendTo('#mention_integration');
 
     // Initialize Mention control.
-    let emailObj: Mention = new Mention({
+        emailObj = new Mention({
         dataSource: emailData,
         fields: { text: 'Name' },
         suggestionCount: 8,


### PR DESCRIPTION
### Bug description
 Need to prevent the EnterAction when the mention popup is not in the open state in the mention integration sample on all platforms.     
           
### Root Cause / Analysis
The issue occurs because the mention element is not prevented when the popup is not in an open state.
                
### Reason for not identifying earlier
This particular use case is not tested or considered when development.
                
### Is Breaking issue.?
No

### Is reported by customer in incident/forum.?

No

### Solution Description
The issue is resolved by preventing the mention element when it is not in an open state.

### Areas affected and ensured
NA

### E2E report details against this fix
NA

### Did you included unit test cases.?

No

### Is there any API name changes.?

No

/label ~bug
/assign @ScrumMaster
/cc @ProductOwner
